### PR TITLE
![rel\|abs]order -> offer

### DIFF
--- a/Joinmarket-messaging-protocol.md
+++ b/Joinmarket-messaging-protocol.md
@@ -104,7 +104,7 @@ Valid conversation sequences:
 | TAKER    |      | MAKER |
 | :---------:|:----:|:-------:|
 |!orderbook(public)|>>>||
-|| <<<| ![rel\|abs]order (private)|
+|| <<<| ![rel\|abs]offer (private)|
 || <<<| !tbond (private)|
 
 | TAKER    |      | MAKER |


### PR DESCRIPTION
There's no such command as `relorder` or `absorder`